### PR TITLE
增加两个配置项

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ WHOASKED_STORAGE_DAYS=3
 # 配置示例：WHOASKED_KEYWORDS=["谁问我了","who"]
 WHOASKED_KEYWORDS=["谁问我了"]
 
+# 是否在消息开头加上消息发送者头像, 默认关闭
+WHOASKED_SHOW_AVATAR=False
+
+# 消息发送者头像大小, 可用值: 40/160
+WHOASKED_SHOW_AVATAR_SIZE=40
+
 ```
 
 ## 使用

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ WHOASKED_STORAGE_DAYS=3
 WHOASKED_KEYWORDS=["谁问我了"]
 
 # 是否在消息开头加上消息发送者头像, 默认关闭
-# 正常情况下, 消息中会正常显示消息发送者头像和昵称
-# 由于LLonebot "伪造的消息会以 Bot 身份显示", 所以增加此配置
+# 在使用Napcat作为协议端的情况下, 消息中会正常显示消息发送者头像和昵称
+# 由于部分协议端暂不支持伪造转发, 所以增加此配置
 WHOASKED_SHOW_AVATAR=False
 
-# 消息发送者头像大小, 可用值: 40/160
+# 消息发送者头像大小, 可用值: 40/160，仅在`WHOASKED_SHOW_AVATAR=True`时生效
 WHOASKED_SHOW_AVATAR_SIZE=40
 
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ WHOASKED_STORAGE_DAYS=3
 WHOASKED_KEYWORDS=["谁问我了"]
 
 # 是否在消息开头加上消息发送者头像, 默认关闭
+# 正常情况下, 消息中会正常显示消息发送者头像和昵称
+# 由于LLonebot "伪造的消息会以 Bot 身份显示", 所以增加此配置
 WHOASKED_SHOW_AVATAR=False
 
 # 消息发送者头像大小, 可用值: 40/160

--- a/nonebot_plugin_whoasked/__init__.py
+++ b/nonebot_plugin_whoasked/__init__.py
@@ -182,6 +182,11 @@ async def process_query(bot: Bot, event: GroupMessageEvent, matcher: Matcher):
             # 保留原始消息的发送者信息
             sender_name = msg_data.get("sender_name", "未知用户")
             sender_id = msg_data.get("user_id", "10000")
+
+            isShowAvatar = plugin_config.whoasked_show_avatar
+            if isShowAvatar:
+                avatar_size = plugin_config.whoasked_show_avatar_size
+                node_content_message.append(MessageSegment.image(file=f"https://q1.qlogo.cn/g?b=qq&nk={sender_id}&s={avatar_size}"))
             
             # 处理消息内容
             if msg_data.get('is_reply', False):

--- a/nonebot_plugin_whoasked/config.py
+++ b/nonebot_plugin_whoasked/config.py
@@ -25,6 +25,15 @@ class Config(BaseModel):
         description="触发查询的关键词列表",
     )
 
+    whoasked_show_avatar: bool = Field(
+        default=False,
+        description="是否在消息开头加上消息发送者头像",
+    )
+    whoasked_show_avatar_size: int = Field(
+        default=40,
+        description="消息发送者头像大小, 可用值: 40/160",
+    )
+
     @field_validator("whoasked_keywords")
     def validate_keywords(cls, v: Union[Set[str], List[str], str]):
         if isinstance(v, str):

--- a/nonebot_plugin_whoasked/config.py
+++ b/nonebot_plugin_whoasked/config.py
@@ -63,5 +63,10 @@ class Config(BaseModel):
         except (ValueError, TypeError):
             logger.warning(f"无效的 whoasked_storage_days 配置值: {v}, 使用默认值 3")
             return 3
+    @field_validator("whoasked_show_avatar_size")
+    def validate_avatar_size(cls, v: int):
+        if v not in {40, 160}:
+            raise ValueError("头像大小必须是 40 或 160")
+        return v
 
 plugin_config = get_plugin_config(Config)


### PR DESCRIPTION
```
# 是否在消息开头加上消息发送者头像, 默认关闭
# 正常情况下, 消息中会正常显示消息发送者头像和昵称
# 由于LLonebot "伪造的消息会以 Bot 身份显示", 所以增加此配置
WHOASKED_SHOW_AVATAR=False

# 消息发送者头像大小, 默认40, 可用值: 40/160
WHOASKED_SHOW_AVATAR_SIZE=40
```

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

引入两个配置选项，用于在回复中启用发送者头像显示并自定义其大小，并在启用时将头像集成到消息格式中。

新特性：
- 添加配置选项以选择性地在消息发送者之前添加头像

增强功能：
- 添加配置选项以设置头像大小（40 或 160）

文档：
- 在 README 中记录新的头像显示和大小配置

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce two configuration options to enable sender avatar display in responses and to customize its size, and integrate the avatar into the message formatting when enabled.

New Features:
- Add configuration option to optionally prepend the message sender’s avatar

Enhancements:
- Add configuration option to set the avatar size (40 or 160)

Documentation:
- Document the new avatar display and size configurations in README

</details>